### PR TITLE
Update Python from 3.8 to 3.9

### DIFF
--- a/.github/workflows/automated-updates.yml
+++ b/.github/workflows/automated-updates.yml
@@ -16,7 +16,7 @@ jobs:
             git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Update categories
       run: |
         python3 convert.py categories

--- a/.github/workflows/duplicate-checker.yml
+++ b/.github/workflows/duplicate-checker.yml
@@ -18,7 +18,7 @@ jobs:
       name: Python setup
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install pytest
       run: pip install pytest
     - name: Check for duplicate lines


### PR DESCRIPTION
This PR updates our project from Python 3.8 to Python 3.9, in response to Python 3.8 reaching its official end of life as of October 7, 2024. By upgrading to Python 3.9, we ensure our project remains secure, maintainable, and compatible with future dependencies.