### PR TITLE
Add firetv stick warning in readme closes #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ Protect yourself from Amazon monopoly by using this blocklist!
 To aid in completing the GAFAM PiHole list, here is a list of known Amazon related trackers/spyware.
 
 Note: Some items on the list may break some websites/services so please be prepared to edit/whitelist as needed.
+
+## Warning for Fire TV Stick Users
+
+If you block the domains `fireoscaptiveportal.com` and `firetvcaptiveportal.com`, your Fire TV Stick may repeatedly crash on the home screen, complaining about a lack of network connectivity. Restarting the device will not resolve the issue.
+
+### Solution
+Unblock the domains `fireoscaptiveportal.com` and `firetvcaptiveportal.com` to allow the Fire TV Stick to boot properly. This will still block other Amazon-related domains and ads while ensuring the device functions as expected.
+
+### Reason
+These domains are essential for the Fire TV Stick to establish network connectivity during startup. Blocking them prevents the device from functioning correctly. If you use the Fire TV Stick solely for local media playback (e.g., via VLC and a local NAS), unblocking these domains should not pose any privacy concerns.
+
+### Note
+While avoiding GAFAM devices is ideal, practical constraints may necessitate their use. This solution balances functionality with privacy.


### PR DESCRIPTION
### Summary

This PR updates the README file to include a detailed explanation regarding the compatibility of the Fire TV Stick with the blocklist. It provides a solution for users experiencing crashes on the home screen due to blocked domains essential for network connectivity.

closes #47